### PR TITLE
Add WAV file selection and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ClearSay
 
-ClearSay is a simple desktop application to help children like William practice speech. The initial version displays text from a placeholder model when the user clicks the **Start Transcription** button.
+ClearSay is a simple desktop application to help children like William practice speech. When you click **Start Transcription**, a file dialog opens so you can choose a `.wav` recording, which is then transcribed using a fine-tuned Whisper model.
 
 ## Requirements
 

--- a/app/app.py
+++ b/app/app.py
@@ -1,4 +1,5 @@
 import customtkinter as ctk
+from tkinter import filedialog, messagebox
 
 # Configure appearance for dark mode
 ctk.set_appearance_mode("dark")
@@ -8,10 +9,21 @@ from model import run_model
 
 
 def start_transcription():
-    """Call the speech-to-text model and display its result."""
-    # Hardcoded audio path for testing until recording is implemented
-    audio_path = "audio_files/test.wav"
-    result = run_model(audio_path)
+    """Prompt for an audio file, transcribe it and display the result."""
+
+    # Ask user to choose a WAV file
+    audio_path = filedialog.askopenfilename(
+        title="Select audio file", filetypes=[("WAV Files", "*.wav")]
+    )
+    if not audio_path:
+        return
+
+    try:
+        result = run_model(audio_path)
+    except Exception as exc:  # Catch model errors or file issues
+        messagebox.showerror("Transcription Error", str(exc))
+        return
+
     text_box.configure(state="normal")
     text_box.delete("1.0", ctk.END)
     text_box.insert(ctk.END, result)


### PR DESCRIPTION
## Summary
- connect the transcription button to a file picker
- show transcription result in the text box
- report errors in a message box
- document new selection behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848916de4508330a5e5b7d2a18e30b9