### PR TITLE
Add auto transcription after recording

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,14 +1,21 @@
 import customtkinter as ctk
-from tkinter import messagebox
+import os
 import queue
 from datetime import datetime
 import wave
+
+from model import run_model
 import numpy as np
 import sounddevice as sd
 
 # Configure appearance for dark mode
+
 ctk.set_appearance_mode("dark")
 ctk.set_default_color_theme("dark-blue")
+
+# Directory where recordings are stored
+RECORDING_DIR = "recorded_audio"
+os.makedirs(RECORDING_DIR, exist_ok=True)
 
 recording = False
 audio_queue: queue.Queue[np.ndarray] = queue.Queue()
@@ -44,13 +51,19 @@ def toggle_recording():
             audio = np.concatenate(frames, axis=0)
             audio = np.int16(audio * 32767)
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            file_path = f"recording_{timestamp}.wav"
+            file_path = os.path.join(RECORDING_DIR, f"recording_{timestamp}.wav")
             with wave.open(file_path, "wb") as wf:
                 wf.setnchannels(1)
                 wf.setsampwidth(2)
                 wf.setframerate(44100)
                 wf.writeframes(audio.tobytes())
-            messagebox.showinfo("Recording Saved", f"Audio saved to {file_path}")
+
+            # Transcribe the saved recording and display the result
+            transcription = run_model(file_path)
+            text_box.configure(state="normal")
+            text_box.delete("1.0", "end")
+            text_box.insert("end", transcription)
+            text_box.configure(state="disabled")
 
         start_button.configure(text="Start Recording")
         recording = False


### PR DESCRIPTION
## Summary
- store recordings in a `recorded_audio` directory
- transcribe each saved recording and display the text in the UI
- keep the recorded_audio folder in repo with a placeholder file

## Testing
- `python -m py_compile app/app.py app/model.py`


------
https://chatgpt.com/codex/tasks/task_e_6848950069a08330b7267c70eabeda37