### PR TITLE
Update button state during transcription

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -48,6 +48,7 @@ def toggle_recording():
             frames.append(audio_queue.get())
 
         if frames:
+            start_button.configure(text="Processing Transcript", state="disabled")
             audio = np.concatenate(frames, axis=0)
             audio = np.int16(audio * 32767)
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -65,7 +66,7 @@ def toggle_recording():
             text_box.insert("end", transcription)
             text_box.configure(state="disabled")
 
-        start_button.configure(text="Start Recording")
+        start_button.configure(text="Start Recording", state="normal")
         recording = False
 
 


### PR DESCRIPTION
## Summary
- disable the UI button after stopping recording
- show "Processing Transcript" text while saving and transcribing
- return button to normal state when done

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848968cfd3883308856f13d17333026