### PR TITLE
Update button state during transcription

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -40,6 +40,8 @@ def toggle_recording():
         start_button.configure(text="Stop Recording")
         recording = True
     else:
+        start_button.configure(text="Processing Transcript", state="disabled")
+        start_button.update_idletasks()
         if stream is not None:
             stream.stop()
             stream.close()
@@ -65,7 +67,7 @@ def toggle_recording():
             text_box.insert("end", transcription)
             text_box.configure(state="disabled")
 
-        start_button.configure(text="Start Recording")
+        start_button.configure(text="Start Recording", state="normal")
         recording = False
 
 


### PR DESCRIPTION
## Summary
- disable the UI button as soon as recording stops
- force UI update before processing audio

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6848968cfd3883308856f13d17333026