### PR TITLE
Add transcript saving, viewer, and README update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ venv/
 
 __pycache__/
 *.pyc
+
+# Generated transcripts and recordings
+transcripts/
+recorded_audio/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ClearSay
 
-ClearSay is a simple desktop application to help children like William practice speech. When you click **Start Transcription**, a file dialog opens so you can choose a `.wav` recording, which is then transcribed using a fine-tuned Whisper model.
+ClearSay is a simple desktop application to help children like William practice speech. Click **Start Recording** and the app records from your microphone before transcribing it with a fine-tuned Whisper model. Each recording is saved in `recorded_audio/` and the matching transcript is written to `transcripts/`.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- persist transcripts to a timestamped file in a new `transcripts/` folder
- show failure or success via a status label
- add a button for viewing past transcripts via a file dialog
- add a button and label to clear or reset transcripts
- update `.gitignore` and README to mention new behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68489b6b4c388330b74a62956c9c8829