### PR TITLE
Add minimal Electron wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,15 @@ python app.py
 ```
 
 The app now uses a single light theme with soft blue accents for readability.
+
+## Electron wrapper
+
+A minimal Electron app lives in `electron/` to package ClearSay for the desktop. Install Node dependencies and launch it in development mode with:
+
+```bash
+cd electron
+npm install
+npm run start
+```
+
+`Option + Space` toggles focus of the window when running on macOS.

--- a/electron/index.html
+++ b/electron/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>ClearSay</title>
+</head>
+<body>
+  <h1>ClearSay Electron</h1>
+  <p>Electron wrapper for the ClearSay app.</p>
+</body>
+</html>

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,37 @@
+const { app, BrowserWindow, globalShortcut } = require('electron');
+let mainWindow;
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  globalShortcut.register('Alt+Space', () => {
+    if (!mainWindow) return;
+    if (mainWindow.isFocused()) {
+      mainWindow.blur();
+    } else {
+      mainWindow.show();
+      mainWindow.focus();
+    }
+  });
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('will-quit', () => {
+  globalShortcut.unregisterAll();
+});

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "clearsay-electron",
+  "version": "1.0.0",
+  "description": "Electron wrapper for ClearSay",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "dist": "electron-builder"
+  },
+  "dependencies": {
+    "electron": "^30.0.0"
+  },
+  "devDependencies": {
+    "electron-builder": "^24.14.1"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize simple Electron environment in `electron/`
- open a BrowserWindow from `main.js` and register a global shortcut
- document how to run the Electron wrapper

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6848d71939ec8330ba29833a85a40a40