### PR TITLE
Build Electron UI

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow, globalShortcut } = require('electron');
+const path = require('path');
 let mainWindow;
 
 function createWindow() {
@@ -11,7 +12,7 @@ function createWindow() {
     },
   });
 
-  mainWindow.loadFile('index.html');
+  mainWindow.loadFile(path.join(__dirname, 'src', 'index.html'));
 }
 
 app.whenReady().then(() => {

--- a/electron/src/app.js
+++ b/electron/src/app.js
@@ -1,0 +1,11 @@
+window.addEventListener('DOMContentLoaded', () => {
+    const copyBtn = document.getElementById('copy-btn');
+    const transcript = document.getElementById('transcript');
+
+    copyBtn.addEventListener('click', () => {
+        const text = transcript.innerText.trim();
+        if (text) {
+            navigator.clipboard.writeText(text);
+        }
+    });
+});

--- a/electron/src/index.html
+++ b/electron/src/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>ClearSay</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;500;700;900&family=Noto+Sans:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <div class="card">
+            <div class="card-header">
+                <h3>Transcript</h3>
+                <button id="copy-btn" aria-label="Copy Transcript">
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <rect x="8" y="8" width="14" height="14" rx="2" ry="2"></rect>
+                        <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path>
+                    </svg>
+                    Copy
+                </button>
+            </div>
+            <div id="transcript" class="transcript" aria-live="polite">
+                <p>Your transcribed text will appear here...</p>
+            </div>
+        </div>
+        <div class="actions">
+            <button id="record-btn" aria-label="Start Recording">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"></path>
+                    <path d="M19 10v2a7 7 0 0 1-14 0v-2"></path>
+                    <line x1="12" y1="19" x2="12" y2="22"></line>
+                </svg>
+                <span>Start Recording</span>
+            </button>
+            <p class="hint">Press the button to start voice transcription.</p>
+        </div>
+    </div>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/electron/src/styles.css
+++ b/electron/src/styles.css
@@ -1,0 +1,154 @@
+:root {
+    --font-family: 'Lexend', 'Noto Sans', sans-serif;
+    --color-bg: #f8fafc;
+    --color-card-bg: #ffffff;
+    --color-border: #e2e8f0;
+    --color-header: #0f172a;
+    --color-button-bg: #f1f5f9;
+    --color-button-text: #334155;
+    --color-button-hover: #e2e8f0;
+    --color-accent: #2563eb;
+    --color-accent-hover: #1d4ed8;
+    --color-hint: #64748b;
+    --radius-md: 12px;
+    --radius-full: 999px;
+    --spacing-4: 1rem;
+    --spacing-6: 1.5rem;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: var(--font-family);
+    background-color: var(--color-bg);
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--spacing-6);
+}
+
+.container {
+    width: 100%;
+    max-width: 700px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-6);
+}
+
+.card {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-card-bg);
+    padding: var(--spacing-6);
+    display: flex;
+    flex-direction: column;
+    height: 400px;
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--spacing-4);
+}
+
+.card-header h3 {
+    margin: 0;
+    color: var(--color-header);
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+#copy-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: var(--color-button-bg);
+    border: none;
+    border-radius: var(--radius-md);
+    color: var(--color-button-text);
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    font-size: 1rem;
+    transition: background-color 0.2s;
+}
+
+#copy-btn:hover {
+    background: var(--color-button-hover);
+}
+
+#copy-btn svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.transcript {
+    flex: 1;
+    overflow-y: auto;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-bg);
+    border-radius: var(--radius-md);
+    padding: var(--spacing-4);
+    color: var(--color-header);
+}
+
+.transcript p {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 700;
+    line-height: 1.6;
+}
+
+.actions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-4);
+}
+
+#record-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.875rem;
+    border: none;
+    border-radius: var(--radius-full);
+    background-color: var(--color-accent);
+    color: #fff;
+    padding: 1.25rem 2.5rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1);
+    transition: background-color 0.2s;
+    width: 100%;
+}
+
+#record-btn:hover {
+    background-color: var(--color-accent-hover);
+}
+
+#record-btn svg {
+    width: 2rem;
+    height: 2rem;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 2.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.hint {
+    margin: 0;
+    color: var(--color-hint);
+    font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- add new Electron `src` folder for renderer assets
- implement mock UI in `index.html`
- recreate Tailwind look via CSS variables
- add basic copy button handling
- point Electron main process at new `index.html`

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6848d78170548330a5e787096a0d618c