### PR TITLE
Add API server for recording and transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ python app.py
 
 The app now uses a single light theme with soft blue accents for readability.
 
+### API server
+
+A lightweight FastAPI server provides recording and transcription endpoints for
+the Electron UI. Launch it with:
+
+```bash
+python -m app.server
+```
+
+The server binds only to `localhost` on port `8000`.
+
 ## Electron wrapper
 
 A minimal Electron app lives in `electron/` to package ClearSay for the desktop. Install Node dependencies and launch it in development mode with:

--- a/app/server.py
+++ b/app/server.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+
+from recorder import Recorder
+from model import run_model
+from constants import RECORDING_DIR
+
+app = FastAPI()
+
+# Allow the Electron UI to make requests
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+recorder = Recorder()
+
+
+@app.post("/record")
+async def record(request: Request):
+    """Start or stop recording based on the ``action`` field."""
+    data = await request.json()
+    action = data.get("action")
+    if action == "start":
+        recorder.start()
+        return {"status": "recording"}
+    if action == "stop":
+        path = recorder.stop()
+        if path is None:
+            raise HTTPException(status_code=400, detail="No audio recorded")
+        return {"file": os.path.basename(path)}
+    raise HTTPException(status_code=400, detail="Invalid action")
+
+
+@app.get("/transcribe")
+async def transcribe(file: str):
+    """Transcribe ``file`` from :data:`RECORDING_DIR`."""
+    path = os.path.join(RECORDING_DIR, file)
+    if not os.path.exists(path):
+        raise HTTPException(status_code=404, detail="File not found")
+    text = run_model(path)
+    return {"transcript": text}
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run("server:app", host="127.0.0.1", port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ customtkinter>=5.2.0
 torch
 openai-whisper
 sounddevice
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add FastAPI server with `/record` and `/transcribe` endpoints
- enable CORS so the Electron UI can call the API
- host server on localhost only
- document API server usage in README
- add `fastapi` and `uvicorn` dependencies

## Testing
- `python -m py_compile app/server.py`


------
https://chatgpt.com/codex/tasks/task_e_6848d7db57488330a96f18523c245273