### PR TITLE
Implement recording client logic

### DIFF
--- a/electron/src/app.js
+++ b/electron/src/app.js
@@ -1,11 +1,69 @@
 window.addEventListener('DOMContentLoaded', () => {
     const copyBtn = document.getElementById('copy-btn');
-    const transcript = document.getElementById('transcript');
+    const recordBtn = document.getElementById('record-btn');
+    const recordBtnText = recordBtn.querySelector('span');
+    const recordBtnIcon = recordBtn.querySelector('svg');
+    const transcriptEl = document.getElementById('transcript');
+
+    const API_PORT = 8000;
+
+    const micIcon = `
+        <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"></path>
+        <path d="M19 10v2a7 7 0 0 1-14 0v-2"></path>
+        <line x1="12" y1="19" x2="12" y2="22"></line>
+    `;
+
+    const stopIcon = `
+        <rect x="6" y="6" width="12" height="12" rx="2" ry="2"></rect>
+    `;
+
+    let recording = false;
 
     copyBtn.addEventListener('click', () => {
-        const text = transcript.innerText.trim();
+        const text = transcriptEl.innerText.trim();
         if (text) {
             navigator.clipboard.writeText(text);
+        }
+    });
+
+    recordBtn.addEventListener('click', async () => {
+        if (!recording) {
+            // Start recording
+            try {
+                await fetch(`http://localhost:${API_PORT}/record`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'start' })
+                });
+                recording = true;
+                recordBtnText.textContent = 'Stop Recording';
+                recordBtnIcon.innerHTML = stopIcon;
+            } catch (err) {
+                console.error('Failed to start recording', err);
+            }
+        } else {
+            // Stop recording
+            try {
+                const res = await fetch(`http://localhost:${API_PORT}/record`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'stop' })
+                });
+                const data = await res.json();
+                if (data && data.file) {
+                    const tRes = await fetch(`http://localhost:${API_PORT}/transcribe?file=${encodeURIComponent(data.file)}`);
+                    const tData = await tRes.json();
+                    if (tData && tData.transcript !== undefined) {
+                        transcriptEl.innerHTML = `<p>${tData.transcript}</p>`;
+                    }
+                }
+            } catch (err) {
+                console.error('Failed to stop recording', err);
+            } finally {
+                recording = false;
+                recordBtnText.textContent = 'Start Recording';
+                recordBtnIcon.innerHTML = micIcon;
+            }
         }
     });
 });


### PR DESCRIPTION
## Summary
- add record button behavior and transcript fetching to electron client
- wire up copy transcript button to clipboard

## Testing
- `npm test --prefix electron` *(fails: Missing script)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d85e4a948330b11826cc02c5bc17