### PR TITLE
Spawn Python server from Electron

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -38,6 +38,12 @@ async def record(request: Request):
     raise HTTPException(status_code=400, detail="Invalid action")
 
 
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
 @app.get("/transcribe")
 async def transcribe(file: str):
     """Transcribe ``file`` from :data:`RECORDING_DIR`."""


### PR DESCRIPTION
## Summary
- add `/health` endpoint for fast API server
- spawn Python server when Electron launches and wait for server readiness
- kill server on exit and show a dialog if it fails

## Testing
- `python -m py_compile app/server.py`
- `node --check electron/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6848d86e8e308330a8b713bcb7d62d93