### PR TITLE
Add build config for electron packaging

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -12,5 +12,28 @@
   },
   "devDependencies": {
     "electron-builder": "^24.14.1"
+  },
+  "build": {
+    "appId": "com.clearsay.app",
+    "asar": true,
+    "files": [
+      "**/*",
+      "../dist/**"
+    ],
+    "extraResources": [
+      {
+        "from": "../dist",
+        "to": "server",
+        "filter": ["**/*"]
+      }
+    ],
+    "mac": {
+      "target": ["dmg"],
+      "artifactName": "ClearSay.dmg"
+    },
+    "win": {
+      "target": ["nsis"],
+      "artifactName": "ClearSay.exe"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- configure electron-builder in `electron/package.json`
- output dmg/NSIS installers
- bundle PyInstaller server binary into the build

## Testing
- `python -m py_compile $(find app -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848d90465c883308d2145d16b94ad85