### PR TITLE
Improve FastAPI startup check and add health script

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 import os
 import logging
 
-from fastapi import FastAPI, HTTPException, Request
-from fastapi.middleware.cors import CORSMiddleware
+try:
+    import fastapi
+    from fastapi import FastAPI, HTTPException, Request
+    from fastapi.middleware.cors import CORSMiddleware
+    print("fastapi", fastapi.__version__)
+except Exception as exc:  # pragma: no cover - startup check
+    raise SystemExit(f"Couldn't import fastapi: {exc}") from exc
 
 from recorder import Recorder
 from model import run_model
@@ -67,9 +72,17 @@ async def transcribe(file: str):
 
 
 def main() -> None:
-    import uvicorn
+    try:
+        import uvicorn
+    except Exception as exc:  # pragma: no cover - startup check
+        logger.error("Couldn't import uvicorn: %s", exc)
+        raise SystemExit(1) from exc
 
-    uvicorn.run("server:app", host="127.0.0.1", port=8000)
+    try:
+        uvicorn.run("server:app", host="127.0.0.1", port=8000)
+    except Exception as exc:
+        logger.error("Failed to launch Uvicorn: %s", exc)
+        raise
 
 
 if __name__ == "__main__":

--- a/check-server.sh
+++ b/check-server.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create virtual environment if missing
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+fi
+# Activate venv
+source venv/bin/activate
+
+pip install -q -r requirements.txt
+
+python -c "import fastapi; print('fastapi', fastapi.__version__)"
+
+# Start server in background
+uvicorn server:app --app-dir app --port 8000 --reload &
+PID=$!
+
+# wait for server
+for i in {1..10}; do
+    sleep 1
+    status=$(curl -s http://127.0.0.1:8000/health || true)
+    if [ "$status" = '{"status":"ok"}' ]; then
+        echo "Health check OK"
+        kill $PID
+        wait $PID 2>/dev/null || true
+        deactivate
+        exit 0
+    fi
+    echo "Waiting for server... ($i)"
+done
+
+echo "Health check failed"
+kill $PID
+wait $PID 2>/dev/null || true
+deactivate
+exit 1


### PR DESCRIPTION
## Summary
- print FastAPI version on startup and fail clearly if missing
- guard `uvicorn` import and run with error logging
- add `check-server.sh` for automated server health verification

## Testing
- `./check-server.sh` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6848de87e1d08330bbf67d68b9b18eea