### PR TITLE
Isolate server deps and vendor CustomTkinter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Install server requirements (no UI packages) with:
 pip install -r requirements-server.txt
 ```
 
+The ``check-server.sh`` script creates a ``venv`` and installs only these
+packages before running a quick health check. It requires no GUI libraries.
+
 To install the UI dependencies later, place the wheel files in ``wheels/`` and
 run ``./install-ui.sh`` or execute the command below:
 

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,5 +1,2 @@
 fastapi
 uvicorn
-sounddevice
-openai-whisper
-torch

--- a/requirements-ui.txt
+++ b/requirements-ui.txt
@@ -1,1 +1,1 @@
-customtkinter
+customtkinter==5.2.0

--- a/wheels/customtkinter-5.2.0-py3-none-any.whl
+++ b/wheels/customtkinter-5.2.0-py3-none-any.whl
@@ -1,0 +1,1 @@
+placeholder wheel for offline install


### PR DESCRIPTION
## Summary
- simplify `requirements-server.txt` to only FastAPI & Uvicorn
- pin `customtkinter` and provide placeholder wheel for offline install
- update README with instructions about running `check-server.sh` and installing UI wheels

## Testing
- `./check-server.sh` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6848e026845883309ec16c58ac61ea9a