### PR TITLE
Support running transcript buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ClearSay
 
-ClearSay is a simple desktop application to help children like William practice speech. Click **Start Recording** and the app records from your microphone before transcribing it with a fine-tuned Whisper model. Each recording is saved in `recorded_audio/` and the matching transcript is written to `transcripts/`.
+ClearSay is a simple desktop application to help children like William practice speech. Click **Start Recording** and the app records from your microphone before transcribing it with a fine-tuned Whisper model.
+
+Transcripts now accumulate in a single buffer so you can pause and resume dictation. Every recording is appended to a time-stamped transcript file in `transcripts/` and the accompanying audio clip is saved alongside it.
 
 ## Requirements
 

--- a/app/buffer_manager.py
+++ b/app/buffer_manager.py
@@ -1,0 +1,40 @@
+import os
+import shutil
+from datetime import datetime
+from typing import List, Optional
+
+from constants import TRANSCRIPT_DIR
+
+
+class TranscriptBuffer:
+    """Accumulate transcription segments and persist to disk."""
+
+    def __init__(self) -> None:
+        self.base_timestamp: Optional[str] = None
+        self.text_parts: List[str] = []
+        self.counter = 1
+        self.transcript_path: Optional[str] = None
+
+    def append(self, text: str, audio_path: str) -> None:
+        """Append a transcription and copy the audio file."""
+        if not text:
+            return
+        if self.base_timestamp is None:
+            self.base_timestamp = datetime.now().strftime("%Y-%m-%d_%H%M")
+            self.transcript_path = os.path.join(
+                TRANSCRIPT_DIR, f"{self.base_timestamp}.txt"
+            )
+        if os.path.exists(audio_path):
+            dest = os.path.join(
+                TRANSCRIPT_DIR,
+                f"{self.base_timestamp}_{self.counter:03d}.wav",
+            )
+            try:
+                shutil.copy2(audio_path, dest)
+            except OSError:
+                pass
+        self.text_parts.append(text.strip())
+        os.makedirs(TRANSCRIPT_DIR, exist_ok=True)
+        with open(self.transcript_path, "w", encoding="utf-8") as f:
+            f.write("\n\n".join(self.text_parts) + "\n")
+        self.counter += 1

--- a/app/server.py
+++ b/app/server.py
@@ -14,6 +14,7 @@ except Exception as exc:  # pragma: no cover - startup check
 from recorder import Recorder
 from model import run_model
 from constants import RECORDING_DIR
+from buffer_manager import TranscriptBuffer
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -29,6 +30,7 @@ app.add_middleware(
 )
 
 recorder = Recorder()
+transcript_buffer = TranscriptBuffer()
 
 
 @app.post("/record")
@@ -68,6 +70,8 @@ async def transcribe(file: str):
     except Exception as exc:  # broad but ensures we never crash
         logger.exception("run_model failed for %s", path)
         raise HTTPException(status_code=500, detail="Transcription failed") from exc
+
+    transcript_buffer.append(text, path)
     return {"transcript": text}
 
 

--- a/electron/src/app.js
+++ b/electron/src/app.js
@@ -19,6 +19,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
     let recording = false;
     let processing = false;
+    const transcriptBuffer = [];
 
     copyBtn.addEventListener('click', () => {
         const text = transcriptEl.innerText.trim();
@@ -67,7 +68,8 @@ window.addEventListener('DOMContentLoaded', () => {
                     const tRes = await fetch(`http://localhost:${API_PORT}/transcribe?file=${encodeURIComponent(data.file)}`);
                     const tData = await tRes.json();
                     if (tData && tData.transcript !== undefined) {
-                        transcriptEl.innerHTML = `<p>${tData.transcript}</p>`;
+                        transcriptBuffer.push(tData.transcript);
+                        transcriptEl.innerHTML = transcriptBuffer.map(t => `<p>${t}</p>`).join('');
                     }
                 }
             } catch (err) {


### PR DESCRIPTION
## Summary
- add TranscriptBuffer module to accumulate recordings
- update server to use TranscriptBuffer when transcribing
- append results in the Electron UI instead of replacing text
- clarify transcript behaviour in README

## Testing
- `bash check-server.sh` *(fails: Could not install fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6849b245cb0c8330860739db06069834