### PR TITLE
Implement timestamped file naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ClearSay is a simple desktop application to help children like William practice speech. Click **Start Recording** and the app records from your microphone before transcribing it with a fine-tuned Whisper model.
 
-Transcripts now accumulate in a single buffer so you can pause and resume dictation. Every recording is appended to a time-stamped transcript file in `transcripts/` and the accompanying audio clip is saved alongside it.
+Transcripts now accumulate in a single buffer so you can pause and resume dictation. Each recording is saved in `recorded_audio/` as `RECORDING_YYYY_MM_DD_HH_MM.wav`. The matching transcript is written to `transcripts/` with the identical timestamp, e.g. `TRANSCRIPT_YYYY_MM_DD_HH_MM.txt`.
 
 ## Requirements
 

--- a/app/buffer_manager.py
+++ b/app/buffer_manager.py
@@ -3,7 +3,7 @@ import shutil
 from datetime import datetime
 from typing import List, Optional
 
-from constants import TRANSCRIPT_DIR
+from constants import TRANSCRIPT_DIR, TIMESTAMP_FORMAT
 
 
 class TranscriptBuffer:
@@ -20,14 +20,14 @@ class TranscriptBuffer:
         if not text:
             return
         if self.base_timestamp is None:
-            self.base_timestamp = datetime.now().strftime("%Y-%m-%d_%H%M")
+            self.base_timestamp = datetime.now().strftime(TIMESTAMP_FORMAT)
             self.transcript_path = os.path.join(
-                TRANSCRIPT_DIR, f"{self.base_timestamp}.txt"
+                TRANSCRIPT_DIR, f"TRANSCRIPT_{self.base_timestamp}.txt"
             )
         if os.path.exists(audio_path):
             dest = os.path.join(
                 TRANSCRIPT_DIR,
-                f"{self.base_timestamp}_{self.counter:03d}.wav",
+                f"RECORDING_{self.base_timestamp}_{self.counter:03d}.wav",
             )
             try:
                 shutil.copy2(audio_path, dest)

--- a/app/constants.py
+++ b/app/constants.py
@@ -10,6 +10,9 @@ BUTTON_HOVER = "#b0d4ff"
 # Recording parameters
 SAMPLE_RATE = 44100
 
+# Shared timestamp format for recordings and transcripts
+TIMESTAMP_FORMAT = "%Y_%m_%d_%H_%M"
+
 # Directories for recorded audio and saved transcripts
 RECORDING_DIR = os.path.join(ROOT_DIR, "recorded_audio")
 TRANSCRIPT_DIR = os.path.join(ROOT_DIR, "transcripts")

--- a/app/recorder.py
+++ b/app/recorder.py
@@ -7,7 +7,7 @@ from typing import Optional
 import numpy as np
 import sounddevice as sd
 
-from constants import RECORDING_DIR, SAMPLE_RATE
+from constants import RECORDING_DIR, SAMPLE_RATE, TIMESTAMP_FORMAT
 
 
 class Recorder:
@@ -17,6 +17,7 @@ class Recorder:
         self.audio_queue: queue.Queue[np.ndarray] = queue.Queue()
         self.stream: Optional[sd.InputStream] = None
         self.recording = False
+        self.last_timestamp: Optional[str] = None
 
     def _callback(self, indata, frames, time, status):
         if status:
@@ -68,8 +69,9 @@ class Recorder:
             return None
         audio = np.concatenate(frames, axis=0)
         audio = np.int16(audio * 32767)
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        file_path = os.path.join(RECORDING_DIR, f"recording_{timestamp}.wav")
+        timestamp = datetime.now().strftime(TIMESTAMP_FORMAT)
+        self.last_timestamp = timestamp
+        file_path = os.path.join(RECORDING_DIR, f"RECORDING_{timestamp}.wav")
         with wave.open(file_path, "wb") as wf:
             wf.setnchannels(1)
             wf.setsampwidth(2)

--- a/app/transcripts.py
+++ b/app/transcripts.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 from typing import List, Optional
 
-from constants import TRANSCRIPT_DIR
+from constants import TRANSCRIPT_DIR, TIMESTAMP_FORMAT
 
 
 class TranscriptManager:
@@ -11,14 +11,15 @@ class TranscriptManager:
     def __init__(self) -> None:
         self.current_path: Optional[str] = None
 
-    def save(self, text: str) -> Optional[str]:
+    def save(self, text: str, timestamp: Optional[str] = None) -> Optional[str]:
         """Write ``text`` to the current transcript file."""
         if not text:
             return None
         if self.current_path is None:
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            if timestamp is None:
+                timestamp = datetime.now().strftime(TIMESTAMP_FORMAT)
             self.current_path = os.path.join(
-                TRANSCRIPT_DIR, f"transcript_{timestamp}.txt"
+                TRANSCRIPT_DIR, f"TRANSCRIPT_{timestamp}.txt"
             )
         os.makedirs(TRANSCRIPT_DIR, exist_ok=True)
         try:

--- a/app/ui.py
+++ b/app/ui.py
@@ -15,6 +15,7 @@ class ClearSayUI:
         self.recorder = recorder
         self.transcripts = transcripts
         self.sidebar_visible = False
+        self.current_timestamp: str | None = None
 
         # App root must exist before any Tk variables are created
         self.app: ctk.CTk | None = None
@@ -204,6 +205,7 @@ class ClearSayUI:
             self.start_button.update_idletasks()
             file_path = self.recorder.stop()
             if file_path:
+                self.current_timestamp = self.recorder.last_timestamp
                 threading.Thread(
                     target=self.process_transcription,
                     args=(file_path,),
@@ -246,7 +248,7 @@ class ClearSayUI:
 
     def save_current_transcript(self) -> None:
         text = self.text_box.get("1.0", "end").strip()
-        path = self.transcripts.save(text)
+        path = self.transcripts.save(text, self.current_timestamp)
         if path is None:
             self.status_label.configure(text="Failed to save transcript")
             return
@@ -259,6 +261,7 @@ class ClearSayUI:
         self.text_box.delete("1.0", "end")
         self.text_box.configure(state="disabled")
         self.transcripts.new()
+        self.current_timestamp = None
 
     def new_transcription(self) -> None:
         self.clear_transcript()


### PR DESCRIPTION
## Summary
- introduce a shared `TIMESTAMP_FORMAT`
- save recordings as `RECORDING_<timestamp>.wav`
- save transcripts as `TRANSCRIPT_<timestamp>.txt`
- keep the timestamp in `Recorder` and pass it to `TranscriptManager`
- document the naming scheme in the README

## Testing
- `python -m py_compile app/*.py`
- `./check-server.sh` *(fails: Could not install fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6849b37598148330b8a8bd134c53a0eb