### PR TITLE
Add export modal and docx backend

### DIFF
--- a/app/buffer_manager.py
+++ b/app/buffer_manager.py
@@ -38,3 +38,14 @@ class TranscriptBuffer:
         with open(self.transcript_path, "w", encoding="utf-8") as f:
             f.write("\n\n".join(self.text_parts) + "\n")
         self.counter += 1
+
+    def get_full(self) -> str:
+        """Return the entire buffered transcript."""
+        return "\n\n".join(self.text_parts)
+
+    def reset(self) -> None:
+        """Clear the current buffer."""
+        self.base_timestamp = None
+        self.text_parts.clear()
+        self.counter = 1
+        self.transcript_path = None

--- a/electron/src/export-modal.css
+++ b/electron/src/export-modal.css
@@ -1,0 +1,63 @@
+#export-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    font-family: var(--font-family);
+}
+#export-modal.show {
+    display: flex;
+}
+#export-modal .overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0,0,0,0.4);
+}
+#export-modal .modal {
+    position: relative;
+    background: #fff;
+    padding: 1.5rem;
+    border-radius: var(--radius-md);
+    display: flex;
+    gap: 1rem;
+    z-index: 1;
+}
+#export-modal .export-tile {
+    width: 150px;
+    height: 150px;
+    background: var(--color-button-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    user-select: none;
+    color: var(--color-button-text);
+    font-weight: 600;
+    text-align: center;
+    padding: 0.5rem;
+    transition: background-color 0.2s;
+}
+#export-modal .export-tile:hover {
+    background: var(--color-button-hover);
+}
+.export-toast {
+    position: fixed;
+    bottom: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #333;
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s;
+    z-index: 1001;
+}
+.export-toast.show {
+    opacity: 1;
+}

--- a/electron/src/index.html
+++ b/electron/src/index.html
@@ -6,6 +6,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;500;700;900&family=Noto+Sans:wght@400;500;700;900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="export-modal.css">
 </head>
 <body>
     <div class="container">
@@ -35,8 +36,18 @@
                 <p>Your transcribed text will appear here...</p>
             </div>
         </div>
-        
+        <button id="done-btn" class="done-btn">Done</button>
     </div>
+
+    <div id="export-modal" class="export-modal">
+        <div class="overlay"></div>
+        <div class="modal">
+            <div class="export-tile" data-action="copy">Copy</div>
+            <div class="export-tile" data-action="docx">Save as .docx</div>
+            <div class="export-tile" data-action="new">New Document</div>
+        </div>
+    </div>
+
     <script src="app.js"></script>
 </body>
 </html>

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+python-docx


### PR DESCRIPTION
## Summary
- create modal overlay for export with copy/docx/new actions
- style modal separately in `export-modal.css`
- implement front-end logic for exporting transcript and resetting
- add `get_full` and `reset` methods to `TranscriptBuffer`
- add `/export-docx` endpoint using `python-docx`
- include `python-docx` in server requirements

## Testing
- `bash check-server.sh` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6849bbe6a2488330baea06b3d7133cd4