### PR TITLE
Fix FastAPI server launch

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -130,7 +130,9 @@ def main() -> None:
         raise SystemExit(1) from exc
 
     try:
-        uvicorn.run("server:app", host="127.0.0.1", port=8000)
+        # Run the FastAPI ``app`` directly to avoid import path issues when
+        # this module is executed with ``python -m app.server``.
+        uvicorn.run(app, host="127.0.0.1", port=8000)
     except Exception as exc:
         logger.error("Failed to launch Uvicorn: %s", exc)
         raise


### PR DESCRIPTION
## Summary
- avoid uvicorn import path problems when running `python -m app.server`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash check-server.sh` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6849be43e1d48330aaa3ea781f78155c