### PR TITLE
Improve server launch reliability

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -7,14 +7,16 @@ let mainWindow;
 let serverProcess;
 const SERVER_PORT = 8000;
 const ROOT_DIR = path.join(__dirname, '..');
-const PYTHON_BIN = process.platform === 'win32' ? 'python' : 'python3';
+const PYTHON_BIN = process.env.VIRTUAL_ENV
+  ? path.join(process.env.VIRTUAL_ENV, 'bin', process.platform === 'win32' ? 'python.exe' : 'python')
+  : (process.platform === 'win32' ? 'python' : 'python3');
 
 function startServer() {
   return new Promise((resolve, reject) => {
     serverProcess = spawn(PYTHON_BIN, ['-m', 'app.server'], { cwd: ROOT_DIR });
     serverProcess.on('error', reject);
 
-    const maxAttempts = 20;
+    const maxAttempts = 40; // allow more time for heavy dependencies
     let attempts = 0;
     const timer = setInterval(() => {
       http.get(`http://127.0.0.1:${SERVER_PORT}/health`, res => {

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,3 +1,6 @@
 fastapi
 uvicorn
 python-docx
+sounddevice
+torch
+whisper


### PR DESCRIPTION
## Summary
- check virtual environment for python executable in Electron app
- increase wait time for server startup
- include sounddevice, torch, and whisper in server requirements

## Testing
- `./check-server.sh` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6849c34c3dd88330b4e5cfbb5e7dbb9a