### PR TITLE
Simplify export endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ python -m app.server
 
 The server binds only to `localhost` on port `8000`.
 
+### Exporting transcripts
+
+The optional DOCX export previously depended on `python-docx`. To simplify
+setup, the `/export-docx` endpoint now saves plain text files instead. Any text
+sent to this endpoint will be written to `transcripts/EXPORT_YYYY_MM_DD_HH_MM_SS.txt`.
+
 ## Electron wrapper
 
 A minimal Electron app lives in `electron/` to package ClearSay for the desktop. Install Node dependencies and launch it in development mode with:

--- a/app/server.py
+++ b/app/server.py
@@ -122,7 +122,7 @@ async def get_transcript(name: str):
 
 @app.post("/export-docx")
 async def export_docx(request: Request):
-    """Export provided text to a DOCX file in ``TRANSCRIPT_DIR``."""
+    """Save provided text to a ``.txt`` file in ``TRANSCRIPT_DIR``."""
     data = await request.json()
     text = (data.get("text") or "").strip()
     if not text:
@@ -130,17 +130,10 @@ async def export_docx(request: Request):
 
     os.makedirs(TRANSCRIPT_DIR, exist_ok=True)
     timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-    path = os.path.join(TRANSCRIPT_DIR, f"EXPORT_{timestamp}.docx")
+    path = os.path.join(TRANSCRIPT_DIR, f"EXPORT_{timestamp}.txt")
 
-    try:
-        from docx import Document
-    except Exception as exc:  # pragma: no cover - missing optional dep
-        logger.error("python-docx not installed: %s", exc)
-        raise HTTPException(status_code=500, detail="DOCX export unavailable")
-    doc = Document()
-    for para in text.split("\n"):
-        doc.add_paragraph(para)
-    doc.save(path)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
 
     return {"path": path}
 

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,6 +1,5 @@
 fastapi
 uvicorn
-python-docx
 sounddevice
 torch
 whisper

--- a/ui/ExportModal.js
+++ b/ui/ExportModal.js
@@ -27,7 +27,7 @@ export default function ExportModal({ open, onClose }) {
     if (text) navigator.clipboard.writeText(text);
   };
 
-  const saveDocx = () => {
+  const saveFile = () => {
     const text = bufferManager.getFull();
     fetch('http://localhost:8000/export-docx', {
       method: 'POST',
@@ -50,7 +50,7 @@ export default function ExportModal({ open, onClose }) {
     <div className="export-overlay" onClick={handleOverlay}>
       <div className="export-modal">
         <button className="tile" onClick={copyText}>Copy</button>
-        <button className="tile" onClick={saveDocx}>Save as .docx</button>
+        <button className="tile" onClick={saveFile}>Save to file</button>
         <button className="tile" onClick={newDoc}>New Document</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- drop `python-docx` from server dependencies
- switch `/export-docx` endpoint to save plain text files
- adjust UI to use new simplified export
- document simplified export in README

## Testing
- `bash check-server.sh` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6849c55bddf883308891ed4d0580ca55