### PR TITLE
Implement transcript autosave with timestamped files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ClearSay is a simple desktop application to help children like William practice speech. Click **Start Recording** and the app records from your microphone before transcribing it with a fine-tuned Whisper model.
 
-Transcripts now accumulate in a single buffer so you can pause and resume dictation. Each recording is saved in `recorded_audio/` as `RECORDING_YYYY_MM_DD_HH_MM.wav`. The matching transcript is written to `transcripts/` with the identical timestamp, e.g. `TRANSCRIPT_YYYY_MM_DD_HH_MM.txt`.
+Transcripts accumulate in a single buffer so you can pause and resume dictation. Each recording is saved in `recorded_audio/` as `RECORDING_YYYY-MM-DD_HH-MM-SS.wav`. The matching transcript is written to `transcripts/` with the identical timestamp, e.g. `YYYY-MM-DD_HH-MM-SS.txt`.
 
 ## Requirements
 

--- a/app/constants.py
+++ b/app/constants.py
@@ -11,7 +11,8 @@ BUTTON_HOVER = "#b0d4ff"
 SAMPLE_RATE = 44100
 
 # Shared timestamp format for recordings and transcripts
-TIMESTAMP_FORMAT = "%Y_%m_%d_%H_%M"
+# Use seconds for easier pairing of audio and text
+TIMESTAMP_FORMAT = "%Y-%m-%d_%H-%M-%S"
 
 # Directories for recorded audio and saved transcripts
 RECORDING_DIR = os.path.join(ROOT_DIR, "recorded_audio")

--- a/app/transcripts.py
+++ b/app/transcripts.py
@@ -19,7 +19,7 @@ class TranscriptManager:
             if timestamp is None:
                 timestamp = datetime.now().strftime(TIMESTAMP_FORMAT)
             self.current_path = os.path.join(
-                TRANSCRIPT_DIR, f"TRANSCRIPT_{timestamp}.txt"
+                TRANSCRIPT_DIR, f"{timestamp}.txt"
             )
         os.makedirs(TRANSCRIPT_DIR, exist_ok=True)
         try:

--- a/app/ui.py
+++ b/app/ui.py
@@ -227,7 +227,7 @@ class ClearSayUI:
     def _update_transcription_ui(self, transcription: str) -> None:
         self.text_box.configure(state="normal")
         if self.text_box.get("1.0", "end").strip():
-            self.text_box.insert("end", "\n" + transcription)
+            self.text_box.insert("end", "\n\n" + transcription)
         else:
             self.text_box.insert("end", transcription)
         self.text_box.configure(state="disabled")


### PR DESCRIPTION
## Summary
- use a timestamp format with seconds for pairing text and audio
- extract timestamp from the audio file in `TranscriptBuffer`
- save transcripts using that timestamp with no prefix
- keep a blank line between transcribed segments in the UI
- update README to document new filenames

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b0059f660833092e813dbdfb0cd75