### PR TITLE
Add ClearSay header

### DIFF
--- a/electron/src/index.html
+++ b/electron/src/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
     <div class="container">
+        <h1 class="app-title">ClearSay</h1>
         <div class="card">
             <div class="card-header">
                 <h3>Transcript</h3>

--- a/electron/src/styles.css
+++ b/electron/src/styles.css
@@ -39,6 +39,24 @@ body {
     gap: var(--spacing-6);
 }
 
+.app-title {
+    margin: 0;
+    text-align: center;
+    font-size: 2.5rem;
+    font-weight: 700;
+    background: linear-gradient(90deg, var(--color-accent), var(--color-accent-hover));
+    background-size: 200% 200%;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: gradient-move 6s ease infinite;
+}
+
+@keyframes gradient-move {
+    0% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+    100% { background-position: 0% 50%; }
+}
+
 .card {
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);


### PR DESCRIPTION
## Summary
- add a prominent `ClearSay` heading to the Electron UI
- style the new heading with a color gradient animation

## Testing
- `npm test --prefix electron` *(fails: Missing script)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b039db87c8330a98d5b50a64357e0