### PR TITLE
Add delay before retranscription

### DIFF
--- a/electron/src/app.js
+++ b/electron/src/app.js
@@ -44,6 +44,7 @@ window.addEventListener('DOMContentLoaded', () => {
         try {
             const res = await fetch(`http://localhost:${API_PORT}/current_discussion`);
             const data = await res.json();
+            if (suppressLabelUpdate) return;
             if (data.id) {
                 const label = data.name ? data.name : data.id;
                 discussionEl.textContent = `Discussion: ${label}`;
@@ -61,6 +62,7 @@ window.addEventListener('DOMContentLoaded', () => {
                 saveNameBtn.style.display = 'none';
             }
         } catch (_) {
+            if (suppressLabelUpdate) return;
             discussionEl.textContent = 'No active discussion';
             renameBtn.disabled = true;
             renameBtn.style.display = 'none';
@@ -243,7 +245,9 @@ window.addEventListener('DOMContentLoaded', () => {
 
             suppressLabelUpdate = true;
             labelLatestDiscussion();
-            await new Promise(r => setTimeout(r, 50));
+            // Give the browser a moment to paint the discussion name before
+            // kicking off the heavy transcription requests
+            await new Promise(r => setTimeout(r, 200));
 
             for (const [idx, file] of files.entries()) {
                 const p = document.createElement('p');


### PR DESCRIPTION
## Summary
- wait a bit after showing discussion name so it appears before retranscription starts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c6d8173d48330bb99e561b03baebd